### PR TITLE
Changed myGPA elements z-index to be 999

### DIFF
--- a/pivot/static/pivot/css/styles.css
+++ b/pivot/static/pivot/css/styles.css
@@ -857,7 +857,7 @@ p.course-table-row {
     border-right:2px dashed red;
     position: absolute;
     top:0px;
-    z-index:1000;
+    z-index: 999;
 }
 
 .gpaLabel {
@@ -866,7 +866,7 @@ p.course-table-row {
     color:red;
     font-size: 0.85em;
     font-weight: bold;
-    z-index: 1000;
+    z-index: 999;
 }
 
 /* Search: options */


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/GPS-273

Before the red my gpa elements would overlap with the text-box suggestions or the dropdown menu of colleges.

The z-index of both the suggestions (in styles.css) and the dropdown menu (owned by bootstrap) is set to 1000.

I set the z-index of the gpa elements to be 999 so they wouldn't overlap.