### PR TITLE
Fix for GPS-307, replaces dropdownMenu:first-child with dropdownMenu

### DIFF
--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -80,7 +80,7 @@ function displayResults() {
             //Find substring matching search term to make bold
             var substring = _completeMajorMap[maj]["major_full_nm"].substr(index, search_val.length);
             var appendTo = "";
-            if (_completeMajorMap[maj]["college"] == $("#dropdownMenu:first-child").val() && _completeMajorMap[maj]["campus"] == $("#dropdownMenu:first-child").attr("data-campus"))
+            if (_completeMajorMap[maj]["college"] == $("#dropdownMenu").val() && _completeMajorMap[maj]["campus"] == $("#dropdownMenu").attr("data-campus"))
                 appendTo = "#selectedCollege";
             else if (_completeMajorMap[maj]["campus"] == _currentCampus)
                 appendTo = "#currentCampus";
@@ -98,7 +98,7 @@ function displayResults() {
             count++;
         }
         //else if nothing has been entered but a college is selected, load all majors in college
-        else if (search_val.length == 0 && _completeMajorMap[maj]["college"] == $("#dropdownMenu:first-child").val() && _completeMajorMap[maj]["campus"] == $("#dropdownMenu:first-child").attr("data-campus")) {
+        else if (search_val.length == 0 && _completeMajorMap[maj]["college"] == $("#dropdownMenu").val() && _completeMajorMap[maj]["campus"] == $("#dropdownMenu").attr("data-campus")) {
             var appendTo = "#selectedCollege";
             var majText = _completeMajorMap[maj]["major_full_nm"];
             $("#selectedCollege").append(template({major: majText}));
@@ -129,7 +129,7 @@ function showCurrentSelections() {
 
     $(".chosen_major").each(function() {
         var appendTo = "";
-        if (_completeMajorMap[$(this).text()]["college"] == $("#dropdownMenu:first-child").val()) {
+        if (_completeMajorMap[$(this).text()]["college"] == $("#dropdownMenu").val()) {
             appendTo = "#selectedCollege";
         } else if (_completeMajorMap[$(this).text()]["campus"] == _currentCampus) {
             appendTo = "#currentCampus";
@@ -151,7 +151,7 @@ function closeSuggestions() {
 
 //Toggles the Go button if search enabled/disabled
 function toggleGo() {
-    var selectedCol = $("#dropdownMenu:first-child").val();
+    var selectedCol = $("#dropdownMenu").val();
     if (($("#suggestions li.suggested_major").length == 1 && selectedCol == "All") ||
         ($("#currentCampus li.suggested_major").length == 1 && selectedCol == "All") ||
         (selectedCol != "All" && $("#selectedCollege li.suggested_major").length == 1)) {
@@ -166,7 +166,7 @@ function goSearch() {
     //This should only work if a single major matches, otherwise error message
     $("#courseList").html("");
     var search = $("#search").val();
-    var selectedCol = $("#dropdownMenu:first-child").val();
+    var selectedCol = $("#dropdownMenu").val();
     var maj = "";
     //if there is one exact match or multiple matches but 1 in the current campus, show the courses for that major
     if ($("#suggestions li.suggested_major").length == 1 && selectedCol == "All") {

--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -323,12 +323,12 @@ function prepareResults(e) {
     var source = $("#prepare-results").html();
     var template = Handlebars.compile(source);
     $("#suggestions").html(template({
-        selected_campus: $("#dropdownMenu:first-child").val(),
+        selected_campus: $("#dropdownMenu").val(),
         current_campus: _currentCampus
     }));
     //If a college is selected from the dropdown menu or text has been entered in the input field
     //if college selected, should show everything in college AND current selections
-    if ($("#dropdownMenu:first-child").val() != "All" || $("#search").val().length > 0) {
+    if ($("#dropdownMenu").val() != "All" || $("#search").val().length > 0) {
         displayResults();
     } else if ($(".chosen_major").length > 0) { //If nothing has been entered in the text field, but the user has made selections
         showCurrentSelections();
@@ -348,14 +348,14 @@ function finishResults() {
     var source_divider = $("#finish-results-divider").html();
     var template_divider = Handlebars.compile(source_divider);
 
-    if ($("#dropdownMenu:first-child").val() == "All")
+    if ($("#dropdownMenu").val() == "All")
         $("#selectedCollege").remove();
     else {
-        if (all_data_loaded && $("#selectedCollege li").length == 1 && $("#dropdownMenu:first-child").val() != "All") {
+        if (all_data_loaded && $("#selectedCollege li").length == 1 && $("#dropdownMenu").val() != "All") {
             $("#selectedCollege").append(template({
                 message: "No matching major in this college"
             }));
-        } else if ($("#selectedCollege li").length == 1 && $("#dropdownMenu:first-child").val() != "All") {
+        } else if ($("#selectedCollege li").length == 1 && $("#dropdownMenu").val() != "All") {
             $("#selectedCollege").append(template({
                 message: "Loading..."
             }));
@@ -423,7 +423,7 @@ function populateCollegeDropdown() {
         campuses.push("Tacoma");
     }
 
-    $("#dropdownMenu:first-child").val("All");
+    $("#dropdownMenu").val("All");
 
     // Compile the handlebar template
     var source = $("#populate-college-dropdown").html();
@@ -452,9 +452,10 @@ function populateCollegeDropdown() {
     $("#college-dropdown .dropdown-menu li a").click(function(){
         var selection_source = $("#populate-college-dropdown-college-selection").html();
         var selection_template = Handlebars.compile(selection_source);
-        $("#dropdownMenu:first-child").html(selection_template({college_selection: $(this).text()}));
-        $("#dropdownMenu:first-child").val($(this).text());
-        $("#dropdownMenu:first-child").attr("data-campus", $(this).attr("class"));
+
+        $("#dropdownMenu").html(selection_template({college_selection: $(this).text()}));
+        $("#dropdownMenu").val($(this).text());
+        $("#dropdownMenu").attr("data-campus", $(this).attr("class"));
         toggleGo();
         if (window.location.href.indexOf("course-gpa") > -1) {
             // creates a user like click
@@ -514,8 +515,8 @@ function clearCommonSelection() {
 function clearCollegeSelection() {
     var source = $("#populate-college-dropdown-college-selection").html();
     var template = Handlebars.compile(source);
-    $("#dropdownMenu:first-child").html(template({college_selection: "All"}));
-    $("#dropdownMenu:first-child").val("All");
+    $("#dropdownMenu").html(template({college_selection: "All"}));
+    $("#dropdownMenu").val("All");
 }
 
 //NOT IN USE? checks last digit after decimal places, returns true if trailing zero


### PR DESCRIPTION
Problem was a combo of 
https://github.com/uw-it-aca/pivot/blob/develop/pivot/templates/course-gpa.html#L23
and https://stackoverflow.com/questions/46607514/css-first-child-not-working. 

The `#dropdownMenu` on the `course-gpa` page wasn't the first child of its parent (there was a `label` element that came before it), and as a result the code that looked for `$("#dropdownMenu:first-child")` didn't work. 

Replacing all of these with `$("#dropdownMenu")` should be ok as there is only one `dropdownMenu` id element (which is the button that shows the real dropdown) that is used in the code.