### PR TITLE
Fix for GPS-215. Hardcoded distribution popover image width/height

### DIFF
--- a/pivot/templates/handlebars/distribution-help-popover.html
+++ b/pivot/templates/handlebars/distribution-help-popover.html
@@ -6,10 +6,15 @@
 </p>
 
 <p>
-	<img src="{{ boxplot_image }}" alt="GPA distribution graph, called Boxplot, shows 50% of GPAs fall in between lower quartile and upper quartile. ">
+<!-- Note: Hardcoded the width/height of the image so bootstrap popover
+     would recognize it. If the image/popover dimensions are changed
+     you have to change the width/height here to be accurate as well -->
+<img src="{{ boxplot_image }}" style="width:244px;height:197.617px;" alt="GPA distribution graph, called Boxplot, shows 50% of GPAs fall in between lower quartile and upper quartile. ">
 </p>
+
 <p>
 	<a href="/about/" title="More about the boxplot"> Learn more about the Lower Quartile, Median GPA, and Upper Quartile.</a>
 </p>
 
 {% endtplhandlebars %}
+


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/GPS-215

Issue described here:
https://github.com/twbs/bootstrap/issues/5235

Seems to be an issue because there's an image in the popover and the first time the distribution help is clicked on the bootstrap doesn't recognize the image's height/width. Solution seems to be to hardcode it, but that would result in some configuring if we ever want to change the image or the popover dimensions.

I inspected the width and height of the image and found that it had a width of `244px` and height of `197.17px`. Those were the values I hardcoded in the html of the distribution popover.


