### PR TITLE
Bug/gps 245: Showing Alert for Majors with < 5 students

### DIFF
--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -221,7 +221,7 @@ function protectedResult(maj) {
 
     var source = $("#protected-result-warning").html();
     var template = Handlebars.compile(source);
-    $(".protected-result-warning").html(template({search: _completeMajorMap[maj]["major_full_nm"]}));
+    $(".protected-result-warning").html(template({majors: [_completeMajorMap[maj]["major_full_nm"]], plural: false}));
 }
 
 //Hides the suggestion box if user clicks outside it

--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -192,6 +192,7 @@ function goSearch() {
 function noResults() {
     $(".sample-data").css("display","none");
     $("#suggestions").css("display","none");
+    // $(".protected-result-warning").css("display","none");
     $(".no-results-warning").css("display","inline");
     var source = $("#no-results").html();
     var template = Handlebars.compile(source);
@@ -204,11 +205,23 @@ function noResults() {
 function multipleResults() {
     $(".sample-data").css("display","none");
     $("#suggestions").css("display","none");
-    $(".no-results-warning").css("display","inline")
+    $(".protected-result-warning").css("display","none");
+    $(".no-results-warning").css("display","inline");
     var source = $("#multiple-results").html();
     var template = Handlebars.compile(source);
     var search_key = $("input#search").val();
     $(".no-results-warning").html(template({search: search_key}));
+}
+
+function protectedResult(maj) {
+    $(".sample-data").css("display","none");
+    $("#suggestions").css("display","none");
+    $(".results-section").css("display","none");
+    $(".protected-result-warning").css("display","inline");
+
+    var source = $("#protected-result-warning").html();
+    var template = Handlebars.compile(source);
+    $(".protected-result-warning").html(template({search: _completeMajorMap[maj]["major_full_nm"]}));
 }
 
 //Hides the suggestion box if user clicks outside it
@@ -235,12 +248,21 @@ function listCoursesForMajor(maj) {
     $("#clear_majors").css("display","inline");
     $(".results-section").css("display","inline");
     $(".no-results-warning").css("display", "none");
+    $(".protected-result-warning").css("display", "none");
 
     //maj = major code A A-0
     var id = maj.replace(" ","_");
 
     // Compile the dynamic table data and pass it as a variable to outer template.
     var courses = _completeMajorMap[maj]["courses"];
+
+    // If the course has a -1 in it, that means that this major is protected
+    // (does not have more than 5 students), so display an alert
+    if(Object.keys(courses).some(function(k){ return ~k.indexOf("-1") })){
+       protectedResult(maj);
+       return;
+    }
+
     var count = 0;
     // Create a list of all the inner table data
     var inner_table_data = [];

--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -506,6 +506,7 @@ function clearCommonSelection() {
     $("#clear_majors").css("display","none");
     $(".chosen_major").remove();
     $(".no-results-warning").css("display","none");
+    $(".protected-result-warning").css("display","none");
     $("input#search").val("");
     $(".results-section").css("display","none");
     $(".sample-data").css("display","block");

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -41,14 +41,27 @@ function createMajorCard(majors, gpa = null) {
     $(".yourgpa-box").remove();
 
     $(".results-section").css("display","inline"); //Changes css of results section - not sure why
+
     gpa = gpa == "" ? null:gpa;
 
     // Compile template with Handlebars
     var source = $("#create-major-card").html();
     var template = Handlebars.compile(source);
+    var valid_majors = 0;
+    var protected_list = [];
 
     //For each selected major...
     for (var l in majors) {
+
+        var major = filterByMajors([majors[l]]);
+        var med = major[0]["median"];
+        if (med == -1) {
+            // If the median GPA is -1... that means that this major is protected
+            protected_list.push(_completeMajorMap[majors[l]]["major_full_nm"]);
+            continue;
+        }
+
+        valid_majors++;
 
         //draw the major's data "card" in the table
         var id = majors[l].replace(" ","_");
@@ -64,8 +77,6 @@ function createMajorCard(majors, gpa = null) {
         }));
 
         $("#" + id).data("code", majors[l]);
-        var major = filterByMajors([majors[l]]);
-        var med = major[0]["median"];
 
         //Add the initial content for the major
         createBoxForMajor(l, med, id);
@@ -75,8 +86,18 @@ function createMajorCard(majors, gpa = null) {
         //D3 - vars to pass = gpa, id, med, major
 
     }
-    overlayGPA(gpa);
-    showCompareModule(gpa = (gpa == null) ? "":gpa);
+    if (protected_list.length > 0) {
+        // Display a message for the protected majors, if there are any
+        protectedResult(protected_list);
+    }
+
+    if (valid_majors > 0) {
+        overlayGPA(gpa);
+        showCompareModule(gpa = (gpa == null) ? "":gpa);
+    } else {
+        // There were no majors we could display
+        $(".results-section").css("display","none");
+    }
     //$("#loadingModal").modal('hide');
 }
 
@@ -389,6 +410,16 @@ function noResults() {
         search: $("input#search").val()
     }));
     //$("#loadingModal").modal('hide');
+}
+
+function protectedResult(protected_list) {
+    $(".sample-data").css("display","none");
+    $("#suggestions").css("display","none");
+    $(".protected-result-warning").css("display","inline");
+
+    var source = $("#protected-result-warning").html();
+    var template = Handlebars.compile(source);
+    $(".protected-result-warning").html(template({majors: protected_list, plural: (protected_list.length > 1)}));
 }
 
 //Item selection

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -391,22 +391,6 @@ function noResults() {
     //$("#loadingModal").modal('hide');
 }
 
-//Displays message when no results found in selected college
-function noResultsCollege(col) {
-    // Compile no-results-college Handlebars template
-    var source = $("#no-results-college").html();
-    var template = Handlebars.compile(source);
-    $(".sample-data").css("display","none");
-    $("#suggestions").css("display","none");
-    $(".no-results-warning").css("display","block");
-    if (multipleSelected())
-        $(".no-results-warning").addClass("alert alert-info");
-    $(".no-results-warning").html(template({
-        search: $("input#search").val(),
-        college: col
-    }));
-}
-
 //Item selection
 function updateEvents() {
     // Compile update-events Handlebars template

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -160,5 +160,6 @@
 {% include "handlebars/no-results-college.html" %}
 {% include "handlebars/show-compare-module.html" %}
 {% include "handlebars/validate-gpa.html" %}
+{% include "handlebars/protected-result-warning.html" %}
 </body>
 </html>

--- a/pivot/templates/course-gpa.html
+++ b/pivot/templates/course-gpa.html
@@ -56,6 +56,8 @@
             <!-- placeholder for 0 results warning -->
             <section class='no-results-warning' role="alert">
             </section>
+            <section class='protected-result-warning' role="alert">
+            </section>
     <!-- Sample data placeholder -->
     		<section class="sample-data">
                 <img src="{% static "pivot/img/sample-courseGPA.png" %}" alt="a sample course GPAs list - informatics" width="743px" height="666px">

--- a/pivot/templates/handlebars/protected-result-warning.html
+++ b/pivot/templates/handlebars/protected-result-warning.html
@@ -1,7 +1,20 @@
 {% load templatetag_handlebars %}
 {% tplhandlebars "protected-result-warning" %}
 <div class="protected-result-warning alert alert-info" role="alert" aria-atomic="true">
-	<p> <b> Protected Major: {{ search }} </b> </p>
+	{{#if plural}}
+	<!-- List out the majors selected (case on the major.html page) -->
+	<p> <b> Protected Majors:</b> </p>
+		<ul>
+		{{#each majors}}
+			<li> -{{ this }}</li>
+		{{/each}}
+		</ul>
+	<br>
+	{{else}}
+	<!-- Simply just put the major along with the title -->
+	<p> <b> Protected Major: {{ majors.[0] }} </b> </p>
+	{{/if}}
+
 <p>
     To protect students' privacy, we only show data for majors with 5 or more declared students.
 </p>

--- a/pivot/templates/handlebars/protected-result-warning.html
+++ b/pivot/templates/handlebars/protected-result-warning.html
@@ -1,0 +1,10 @@
+{% load templatetag_handlebars %}
+{% tplhandlebars "protected-result-warning" %}
+<div class="protected-result-warning alert alert-info" role="alert" aria-atomic="true">
+	<p> <b> Protected Major: {{ search }} </b> </p>
+<p>
+    To protect students' privacy, we only show data for majors with 5 or more declared students.
+</p>
+
+</div>
+{% endtplhandlebars %}

--- a/pivot/templates/major-gpa.html
+++ b/pivot/templates/major-gpa.html
@@ -55,6 +55,8 @@
            <!-- placeholder for 0 results warning -->
             <div class='no-results-warning' role="alert">
             </div>
+            <div class='protected-result-warning' role="alert">
+            </div>
     <!-- Sample data placeholder -->
     		<section class="sample-data">
                 <img src="{% static "pivot/img/sample-majorGPA.png" %}" alt="Sample major data - informatics" width="743px" height="666px">

--- a/utils/process_data.py
+++ b/utils/process_data.py
@@ -31,7 +31,10 @@ def sort_by_course_and_popularity(a, b):
 
 if (len(sys.argv) < 3):
     sys.exit('Please pass in the Majors and Courses file AND ' +
-             'the Student Data - All Majors file to parse as arguments!')
+             'the Student Data - All Majors file to parse as arguments!\n' +
+             'Example: \npython process_data.py ' +
+             '../data/v8\ -\ Majors\ and\ Courses.csv ' +
+             '../data/v8\ -\ Student\ Data\ -\ All\ Majors.csv')
 
 with open(sys.argv[1]) as f:
     as_csv = csv.reader(f)

--- a/utils/process_data.py
+++ b/utils/process_data.py
@@ -117,7 +117,8 @@ with open('Majors_and_Courses.csv', 'wb') as outf:
 
         median_gpa = data[key]['50']
         course_name = course_name_map[original_row[8]]
-        if (original_row[0].strip() + "_" + original_row[1].strip() in little_majors):
+        maj = original_row[0].strip() + "_" + original_row[1].strip()
+        if (maj in little_majors):
             # Sensitive information turned into -1's!
             original_row[2] = -1
             original_row[3] = -1
@@ -177,7 +178,8 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
                       "q1", "median", "q3", "iqr_max"])
 
     for key in sdata:
-        major_abbr = sdata[key]["raw"][2].strip() + "_" + sdata[key]["raw"][3].strip()
+        major_abbr = sdata[key]["raw"][2].strip() + "_" +\
+                     sdata[key]["raw"][3].strip()
         if major_abbr in little_majors:
             # This major has less than st_num students! Hide the data
             csv_out.writerow([sdata[key]["raw"][2],
@@ -207,7 +209,7 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
             iqr_index_min = 0
             iqr_index_max = len(gpas) - 1
 
-            while iqr_index_min < len(gpas) and gpas[iqr_index_min] < qv1 - iqr:
+            while iqr_index_min < len(gpas) and gpas[iqr_index_min] < qv1-iqr:
                 iqr_index_min += 1
 
             while iqr_index_max > 0 and gpas[iqr_index_max] > qv3 + iqr:


### PR DESCRIPTION
- Refactored the script to remove sensitive data of majors with `< 5` students (replacing stuff like median gpa with `-1`)
- On `major.html` and `course.html` refactored to show a new alert if a user selects a `protected major`

For testing:
- I suggest you run the script yourself to make sure the script churns out the right csv's.

Then you can go ahead and test the client side...

- [ ]  Make sure that it doesn't interfere with the other major methods
- [ ] Make sure the protected majors alert pops up and disappears appropriately
- [ ] Make sure `Clear Selections` works
- [ ] Make sure `Session Storage` works

The 4 protected majors that I found were:
[`South Asian Languages`, 
`Norwegian`, 
`Communication, Evening Degree Program`, 
`Urban Studies (Global Urbanism)`]