### PR TITLE
Remove protected results when major is unchecked

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -89,6 +89,8 @@ function createMajorCard(majors, gpa = null) {
     if (protected_list.length > 0) {
         // Display a message for the protected majors, if there are any
         protectedResult(protected_list);
+    } else {
+        $(".protected-result-warning").css("display","none");
     }
 
     if (valid_majors > 0) {


### PR DESCRIPTION
Missed a minor case.

On `major.html`...
 - Select `Norwegian`
 - Select a valid major
 - Unselect `Norwegian`

The protected warning still exists