### PR TITLE
Bug/gps 298: Show the total N for each major

### DIFF
--- a/pivot/static/pivot/css/styles.css
+++ b/pivot/static/pivot/css/styles.css
@@ -641,10 +641,6 @@ fill: #7C89A4;
     background-color: #7C89A4;
 }
 
-.NUM {
-	background-color: #87CBAC;
-}
-
 /*D3 Boxplot - styling for horizontal line*/
 .boxChart .center {
 

--- a/pivot/static/pivot/css/styles.css
+++ b/pivot/static/pivot/css/styles.css
@@ -641,6 +641,10 @@ fill: #7C89A4;
     background-color: #7C89A4;
 }
 
+.NUM {
+	background-color: #87CBAC;
+}
+
 /*D3 Boxplot - styling for horizontal line*/
 .boxChart .center {
 

--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -213,6 +213,7 @@ function addStudents() {
             major_abbr: d.major_abbr.trim(),
             pathway: d.pathway.trim(),
             college: d.College.trim(),
+            count: d.count.trim(),
             iqr_min: d.iqr_min.trim(),
             q1: d.q1.trim(),
             median: d.median.trim(),

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -180,8 +180,7 @@ function createBoxplot(i, gpa, majorId, median, majorData) {
 
     //Add numbers for screen reader
     $("#" + majorId + " .data-display svg").append("<p class='sr-only'>Lower quartile = " + round(Number($("#" + majorId + " .boxLQ").attr("data")),2) + " median = " + round(Number($("#" + majorId + " .median").attr("data")),2) + " upper quartile = " + round(Number($("#" + majorId + " .boxHQ").attr("data")),2) + "</p>");
-
-    addPopover(majorId, y(median));
+    addPopover(majorId, y(median), majorData[0]["count"]);
 }
 
 //Draw line representing user-entered GPA
@@ -211,7 +210,7 @@ function storeSelections(majors, gpa) {
 
 
 //Initializes the popover for a boxplot
-function addPopover(id, med) {
+function addPopover(id, med, count) {
     // Compile the Handlebars template
     var source = $("#add-popover").html();
     var template = Handlebars.compile(source);
@@ -223,7 +222,8 @@ function addPopover(id, med) {
         content: template({
         lower_quartile: round(Number($("#" + id + " .boxLQ").attr("data")),2),
         median: round(Number($("#" + id + " .median").attr("data")),2),
-        upper_quartile: round(Number($("#" + id + " .boxHQ").attr("data")),2)
+        upper_quartile: round(Number($("#" + id + " .boxHQ").attr("data")),2),
+        count: count
             }),
         container: "#" + id
     });

--- a/pivot/templates/handlebars/add-popover.html
+++ b/pivot/templates/handlebars/add-popover.html
@@ -21,9 +21,8 @@
 </div>
 
 <div class="distributionPopover">
-    <div class='boxLegend NUM'></div>
     <p style='display:inline-block;'>
-        n&nbsp;=&nbsp;{{ count }}
+        Number&nbsp;of&nbsp;Students:&nbsp;{{ count }}
     </p>
 </div>
 </div> <!-- .popover-content-->

--- a/pivot/templates/handlebars/add-popover.html
+++ b/pivot/templates/handlebars/add-popover.html
@@ -19,5 +19,12 @@
         Upper&nbsp;quartile:&nbsp;{{ upper_quartile }}
     </p>
 </div>
+
+<div class="distributionPopover">
+    <div class='boxLegend NUM'></div>
+    <p style='display:inline-block;'>
+        n&nbsp;=&nbsp;{{ count }}
+    </p>
+</div>
 </div> <!-- .popover-content-->
 {% endtplhandlebars %}

--- a/utils/process_data.py
+++ b/utils/process_data.py
@@ -177,8 +177,8 @@ with open(sys.argv[2]) as f:
 
 with open('Student_Data_All_Majors.csv', 'wb') as outf:
     csv_out = csv.writer(outf, delimiter=',')
-    csv_out.writerow(["major_abbr", "pathway", "College", "iqr_min",
-                      "q1", "median", "q3", "iqr_max"])
+    csv_out.writerow(["major_abbr", "pathway", "College", "count",
+                      "iqr_min", "q1", "median", "q3", "iqr_max"])
 
     for key in sdata:
         major_abbr = sdata[key]["raw"][2].strip() + "_" +\
@@ -189,6 +189,7 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
             csv_out.writerow([sdata[key]["raw"][2],
                               sdata[key]["raw"][3],
                               sdata[key]["raw"][5],
+                              -1,
                               -1,
                               -1,
                               -1,
@@ -226,6 +227,7 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
             csv_out.writerow([sdata[key]["raw"][2],
                               sdata[key]["raw"][3],
                               sdata[key]["raw"][5],
+                              len(gpas),
                               gpas[iqr_index_min],
                               qv1,
                               median,

--- a/utils/process_data.py
+++ b/utils/process_data.py
@@ -183,6 +183,7 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
     for key in sdata:
         major_abbr = sdata[key]["raw"][2].strip() + "_" +\
                      sdata[key]["raw"][3].strip()
+
         if major_abbr in little_majors:
             # This major has less than st_num students! Hide the data
             csv_out.writerow([sdata[key]["raw"][2],
@@ -193,7 +194,10 @@ with open('Student_Data_All_Majors.csv', 'wb') as outf:
                               -1,
                               -1,
                               -1])
-
+        elif len(sdata[key]["gpas"]) < st_num:
+            # We need at least st_num GPAs to calculate the
+            # quartile ranges for the boxplot
+            continue
         else:
             gpas = sorted(sdata[key]["gpas"])
             q1 = int(len(gpas) * .25)


### PR DESCRIPTION
Show the total N for each major

`Total N` = `Total Amount of GPAs in the original data` (used to calculate the median and interquartile ranges), not just the number of GPAs within the interquartile range

Had to make changes to the `process_data.py` script to store this information in the processed csv, and then edited the boxplot popover to show this information.


![screen shot 2018-02-09 at 3 50 06 pm](https://user-images.githubusercontent.com/15153943/36055477-8e907c84-0db1-11e8-9ef6-e4c38c7aba8f.png)

UI can be updated, just decided to go with the general format of a legend?

EDIT: NEW UI
![screen shot 2018-02-14 at 3 38 14 pm](https://user-images.githubusercontent.com/15153943/36233910-1d3e62ae-119d-11e8-9e4c-eb842b3e5427.png)
