### PR TITLE
Fix for GPS-319. Setting the container of help popovers to be the maj…

### DIFF
--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -327,13 +327,13 @@ function listCoursesForMajor(maj) {
     $("#percentHelp").popover({
         placement: "top",
         html: true,
-        container: "body",
+        container: ".course-table",
         content: "<p>Percent of students who had taken the course by the time they declared for the major that you've selected.</p>"
     });
     $("#courseGradeHelp").popover({
         placement: "top",
         html: true,
-        container: "body",
+        container: ".course-table",
         content: "<p>Median course grade of students who had taken the course by the time they declared for the major that you've selected.</p>"
     });
     //$("#loadingModal").modal('hide');
@@ -368,3 +368,8 @@ function colorBucket(gpa) {
     }
     return 0;
 }
+
+// Close any open popovers when someone resizes the window!
+$(window).resize(function() {
+    $('a[data-toggle="popover"]:focus').blur();
+});

--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -530,7 +530,7 @@ function addCapacityDescription(id, location) {
             trigger: "focus",
             placement: "top",
             html: true,
-            container: "body",
+            container: "#" + id,
                    content: template({
                 major_status_text: displayMajorStatusText(clear_id)
             })

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -131,7 +131,7 @@ function createBoxForMajor(i, median, majorId) {
             trigger: "focus",
             placement: "top",
             html: true,
-            container: "body",
+            container: "#" + majorId,
             content: median_template({})
         });
 
@@ -139,7 +139,7 @@ function createBoxForMajor(i, median, majorId) {
             trigger: "focus",
             placement: "top",
             html: true,
-            container: "body",
+            container: "#" + majorId,
             content: dist_template({
                 boxplot_image: images_paths["boxplot"]
             })


### PR DESCRIPTION
Bug:
https://jira.cac.washington.edu/browse/GPS-319
Solution:
https://stackoverflow.com/a/25815568

Set the container to be the row of the first major (example: `#CSS-0`) instead of the body. 
Bug seems to disappear after that.
