### PR TITLE
Fix for GPS-271. Adjusting the boxplot domain so the left tickmark shows

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -158,7 +158,8 @@ function createBoxplot(i, gpa, majorId, median, majorData) {
     //create the axes
     var y = d3.scale.ordinal().domain([median]).rangeRoundBands([0, height], 0.7, 0.3);
     var yAxis = d3.svg.axis().scale(y).orient("left");
-    var x = d3.scale.linear().domain([1.5, 4.0]).range([0, width]);
+    // Setting the domain to start from 1.4999 instead of 1.5 so the tick at 1.5 will show
+    var x = d3.scale.linear().domain([1.4999, 4.0]).range([0, width]);
     var xAxis = d3.svg.axis().scale(x).orient("top").ticks(6);
 
     //draw the boxplot


### PR DESCRIPTION
When inspecting the boxplot, it seems like the tickmark is there! It is just being covered up...

This suggestion seems to fix it
https://stackoverflow.com/a/36561245

`Before:`
![screen shot 2018-02-09 at 4 31 17 pm](https://user-images.githubusercontent.com/15153943/36056134-b1478ee8-0db6-11e8-89c9-35f2e8c6a575.png)
`After:`
![screen shot 2018-02-09 at 4 31 11 pm](https://user-images.githubusercontent.com/15153943/36056139-b58977fa-0db6-11e8-9573-685d6f842e56.png)
