### PR TITLE
Adding logic to remove HTML if there is no admission status

### DIFF
--- a/pivot/static/pivot/css/styles.css
+++ b/pivot/static/pivot/css/styles.css
@@ -742,9 +742,12 @@ p.college-heading{
 	margin-top: 10px;
 	margin-bottom: 10px;
 }
-.gpa-small {
-	margin-left: 15px;
+
+/* Adding padding for the course admission popover link */
+.courseAdmissionStatus {
+	margin-right: 15px;
 }
+
 /* Slight tweak of major name on course page */
 .major-heading-course {
 margin-bottom: 2px;

--- a/pivot/templates/handlebars/create-major-card.html
+++ b/pivot/templates/handlebars/create-major-card.html
@@ -6,8 +6,8 @@
 	    <h3 class="sr-only">{{{ major_status_url }}}</h3>
         <p class='college-heading'>{{ college }} - {{ campus }}</p>
         <h4 class='major-heading row'>{{{ major_status_url }}}
-			<!-- TODO: Fill in data-content here for popover-->
-	        <div class="major-status"><a class='inlineHelp' id='major-status-Help' tabindex='0' role='button' aria-label='Info about major status' data-placement='top' data-toggle='popover' data-trigger='focus' data-html='true' data-content=''>{{{ major_status_icon }}}  {{{ major_status_text }}}</a></div></h4>
+			<!-- TODO: Fill in data-content here for popover if major_status_text is defined-->
+	        {{#if major_status_text}}<div class="major-status"><a class='inlineHelp' id='major-status-Help' tabindex='0' role='button' aria-label='Info about major status' data-placement='top' data-toggle='popover' data-trigger='focus' data-html='true' data-content=''>{{{ major_status_icon }}}  {{{ major_status_text }}}</a></div>{{/if}}</h4>
     </div>
 </div>
 

--- a/pivot/templates/handlebars/list-courses-for-major-outer.html
+++ b/pivot/templates/handlebars/list-courses-for-major-outer.html
@@ -6,8 +6,8 @@
     <div class='col-xs-12 course-table'>
         <h2 class='major-heading-course'>{{{ major_status_url }}}</h2>
         <div class='major-gpa-line'>
-            <a class='inlineHelp' id='major-status-Help' tabindex='0' role='button' aria-label='Info about major status' data-placement='top' data-toggle='popover' data-trigger='focus' data-html='true' data-content=''>{{{ major_status_icon }}}  {{{ major_status_text }}}</a>
-            <span class='gpa-small'>  Median GPA: {{{ median_gpa }}} </span>
+           {{#if major_status_text}} <a class='inlineHelp courseAdmissionStatus' id='major-status-Help' tabindex='0' role='button' aria-label='Info about major status' data-placement='top' data-toggle='popover' data-trigger='focus' data-html='true' data-content=''>{{{ major_status_icon }}}  {{{ major_status_text }}}</a>{{/if}}
+            <span>  Median GPA: {{{ median_gpa }}} </span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
I also added a class and styling to a the admission type popover link. This allowed me to remove the gpa-small class from the median GPA. By having the padding associated with the popover link, whenever we do not have an admission type to display, the median GPA will align right.
Here is an example of the Course GPA page with Admission status:

<img width="417" alt="admissionstatus" src="https://user-images.githubusercontent.com/17015418/36336189-74616b6e-133a-11e8-9b19-77142e88c18c.png">

And here is one without:

<img width="412" alt="noadmissionstatus" src="https://user-images.githubusercontent.com/17015418/36336191-7fec9bf2-133a-11e8-88f3-759b250e415c.png">

