### PR TITLE
Replacement for offset.top() use in boxplot popovers on Safari

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -233,12 +233,26 @@ function addPopover(id, med) {
 
     document.querySelector("#" + id + " .boxPopover").addEventListener("focusin", function() {
         $(this).popover("show");
-        $("#" + id + " .popover").css("top", $("#" + id + " .boxP").offset().top - $("#" + id + " .popover").height());
+        var boxEl = document.querySelector("#" + id + " .boxP");
+        // Try using offset.top; won't work on Safari so use getPageTopLeft instead
+        var top = $("#" + id + " .boxP").offset().top || getPageTopLeft(boxEl).top;
+        var calc_top = top - $("#" + id + " .popover").height();
+        $("#" + id + " .popover").css("top", calc_top);
     });
 
     document.querySelector("#" + id + " .boxPopover").addEventListener("focusout", function() {
       $(this).popover("hide");
     });
+}
+
+// Safari doesn't support offset.top so we use this as a workaround
+function getPageTopLeft(el) {
+    var rect = el.getBoundingClientRect();
+    var docEl = document.documentElement;
+    return {
+        left: rect.left + (window.pageXOffset || docEl.scrollLeft || 0),
+        top: rect.top + (window.pageYOffset || docEl.scrollTop || 0)
+    };
 }
 
 //Gets the data associated with the selected majors


### PR DESCRIPTION
The boxplot popover was showing up in Safari, but it was showing up at the very very top of the page were it was off of the visible area. Turns out Safari doesn't support `offset().top`...
`Problem:`
https://stackoverflow.com/questions/24851042/cross-browser-issue-with-jquery-offsettop-returning-different-values
`Solution:`
https://stackoverflow.com/questions/18953144/how-do-i-get-the-offset-top-value-of-an-element-without-using-jquery

