### PR TITLE
Fix for GPS-342. More strict boxplot popover classes to prevent position bug

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -230,11 +230,14 @@ function addPopover(id, med, count) {
         count: count
             }),
         container: "#" + id
-    });
+    })
+    .data('bs.popover')
+    .tip()
+    .addClass("bp"); // ID for the actual boxplot popover
 
     document.querySelector("#" + id + " .boxPopover").addEventListener("focusin", function() {
         $(this).popover("show");
-        $("#" + id + " .popover").css("top", $("#" + id + " .boxP").offset().top - $("#" + id + " .popover").height());
+        $("#" + id + " .bp").css("top", $("#" + id + " .boxP").offset().top - $("#" + id + " .bp").height());
     });
 
     document.querySelector("#" + id + " .boxPopover").addEventListener("focusout", function() {


### PR DESCRIPTION
https://jira.cac.washington.edu/projects/GPS/issues/GPS-342

Added a class to the boxplot popover to fix this bug. Class name is `bp` for conciseness and coolness.