### PR TITLE
Internet Explorer Works? Bug/gps 344

### DIFF
--- a/pivot/static/pivot/js/handlebars_helper.js
+++ b/pivot/static/pivot/js/handlebars_helper.js
@@ -1,5 +1,5 @@
 // Helper function allows us to perfom equality logic within a handlebar template
-Handlebars.registerHelper('ifEquals', (a, b, options) => {
+Handlebars.registerHelper('ifEquals', function(a, b, options) {
   if (a === b) {
     return options.fn(this)
   }

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -26,7 +26,8 @@ function checkStoredData() {
 /**** DISPLAY DATA FOR SELECTED MAJOR(S) ****/
 
 //Main function that draws/redraws the data table whenever a major is been selected
-function createMajorCard(majors, gpa = null) {
+function createMajorCard(majors, gpa) {
+    gpa = (typeof gpa !== 'undefined') ? gpa : null;
     storeSelections(majors, gpa); //Store user's selections
     $(".sample-data").css("display","none"); //Hide the placeholder how-to image
 


### PR DESCRIPTION
When loading Pivot on Internet Explorer, you run into the following JavaScript bugs in the console when on `/majors`.

```
Syntax Error

handlebars_helper.js (2, 56)

Expected ')'

major.js (29, 38)

'checkStoredData' is undefined

main.js (247, 9)

```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters
This wasn't compatible in IE along with
https://stackoverflow.com/questions/40110022/syntax-error-in-ie-using-es6-arrow-functions

There's probably more bugs, but I have to keep exploring

Here's a gif of some of the current behavior:
![ie](https://user-images.githubusercontent.com/15153943/37000271-bd5fbd12-2077-11e8-93e4-6f44d1c9aed3.gif)


Update: Tabbing is a bit sketchy on the majors page, sometimes the tabbing just takes you in a loop without activating any of the popups. Will file a separate bug for this.