### PR TITLE
Fix for GPS-346. Switching to valid alias_index variable name

### DIFF
--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -84,7 +84,7 @@ function displayResults() {
         if (search_alias[maj]) {
             for (var i = 0; i < search_alias[maj].length; i++) {
                 if (search_alias[maj][i].toLowerCase().indexOf(search_val) == 0) {
-                    search_alias_index = true;
+                    alias_index = true;
                     break;
                 }
             }


### PR DESCRIPTION
Search Alias was broken on the `/course-gpa/` page
`Before`
![346before](https://user-images.githubusercontent.com/15153943/37002937-27e741ca-2080-11e8-8147-8fcc80b25a0b.gif)
`After`
![346after](https://user-images.githubusercontent.com/15153943/37002933-2394ef64-2080-11e8-820a-889d86aad756.gif)
