### PR TITLE
Added an explanation of the mixed admission type

### DIFF
--- a/pivot/templates/about.html
+++ b/pivot/templates/about.html
@@ -95,6 +95,9 @@
 						<li class="admission-type-list"><dt>Minimum Requirements/Selective Admission</dt>
 							<dd>Requires students to complete satisfactorily a set of prerequisite courses with a minimum GPA. All students who meet the minimum requirements are admitted.</dd>
 						</li>
+						<li class="admission-type-list"><dt>Mixed Admission</dt>
+                                                	<dd>Entry may be either open, minimum, or capacity-constrained depending on the degree/option chosen.</dd>
+                                                </li>
 				
 				</dl>
 				


### PR DESCRIPTION
![myplan admission types](https://user-images.githubusercontent.com/17015418/37679880-80f59eb8-2c3f-11e8-8a96-cca61bed8431.png)
Used this data to add to our About Pivot page, which was lacking the "mixed" admission type.

Still have one question: Based on this text taken from MyPlan's program explorer, do we want to change the other admission types on pivot to use the same text?