### PR TITLE
Modified Bothell Business major names

### DIFF
--- a/utils/process_data.py
+++ b/utils/process_data.py
@@ -28,7 +28,9 @@ major_name_exc = {
     "OSCM_0": "Business Administration (Operations Supply Chain Management)",
     "HCDE_5": "Human Centered Design and Engineering: " +
               "Human-Computer Interaction",
-    "T_ACCT_0": "Business Administration (Accounting)"
+    "T ACCT_0": "Business Administration (Accounting)",
+    "B BUS_10": "Business Administration (Accounting)",
+    "B BUS_5": "Business Administration (ELC)"
 }
 
 


### PR DESCRIPTION
Using the programs.csv file from the MyPlan team, I modified a couple of the Bothell Business major names to better reflect the data in Myplan. Although we are still lacking multiple data points, as described in the Jira bug: https://jira.cac.washington.edu/browse/GPS-329.