### PR TITLE
Moved the focus on the modal popup window

### DIFF
--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -41,7 +41,8 @@ function initOnboardingDialog() {
         isPermForgotten = isPermForgotten == null ? false : isPermForgotten;
         // if the modal has not been permanently forgotten, show it
         if (isPermForgotten == false || isPermForgotten == "false") {
-            $("#onboard-modal").modal("show");
+	     $("#onboard-modal").modal("show");
+	     $("#perm-forget-modal").focus();
         } else {
             // set temp forgotten to represent forgotten state to
             // prevent execution of multiple if conditions

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -78,7 +78,7 @@
 
     <!-- ADVISOR ONBOARDING -->
     <!-- Modal -->
-    <div class="modal fade" id="onboard-modal" role="dialog" tabindex="-1" aria-labelledby="welcome-adviser" aria-hidden="true">
+    <div class="modal" id="onboard-modal" role="dialog" tabindex="0" aria-labelledby="welcome-adviser" aria-hidden="true">
         <div class="modal-dialog" role="document">
 
             <!-- Modal content-->


### PR DESCRIPTION
Per https://jira.cac.washington.edu/browse/GPS-350, I moved the focus onto the "I got it!" button.

![pivot_intro_modal](https://user-images.githubusercontent.com/17015418/37785281-06bcc56c-2db7-11e8-9a34-7547442d3e22.png)

This is a Stack Overflow article used for reference. By removing the fade class, the modal content becomes the focus on page load.
https://stackoverflow.com/questions/32535878/how-do-i-focus-a-button-inside-modal-when-the-modal-is-opened?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa