### PR TITLE
Removing unnecessary hidden link

### DIFF
--- a/pivot/templates/handlebars/create-major-card.html
+++ b/pivot/templates/handlebars/create-major-card.html
@@ -3,7 +3,6 @@
 
 <div class='major-card row' id='{{ id }}' aria-live="assertive">
     <div class='card-heading col-xs-12 col-md-4 major-height'>
-	    <h3 class="sr-only">{{{ major_status_url }}}</h3>
         <p class='college-heading'>{{ college }} - {{ campus }}</p>
         <h4 class='major-heading row'>{{{ major_status_url }}}
 			<!-- TODO: Fill in data-content here for popover if major_status_text is defined-->


### PR DESCRIPTION
This link caused us to tab to a hidden location, which is confusing to users. With a screen reader, the user would hear the Major name & Myplan Programs Link twice.

https://jira.cac.washington.edu/browse/GPS-357 