### PR TITLE
GPS-358: Fixing behavior of All Colleges in the Dropdown Menu

### DIFF
--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -476,7 +476,11 @@ function populateCollegeDropdown() {
         var selection_template = Handlebars.compile(selection_source);
 
         $("#dropdownMenu").html(selection_template({college_selection: $(this).text()}));
-        $("#dropdownMenu").val($(this).text());
+        if ($(this).text() === "All Colleges") {
+            $("#dropdownMenu").val("All");
+        } else {
+            $("#dropdownMenu").val($(this).text());
+        }
         $("#dropdownMenu").attr("data-campus", $(this).attr("class"));
         toggleGo();
         if (window.location.href.indexOf("course-gpa") > -1) {


### PR DESCRIPTION
I assumed the bug wanted me to make sure All Colleges shares the same value and behavior as All regarding the dropdown menu. 

https://jira.cac.washington.edu/browse/GPS-358

One consequence of the current behavior is that the dropdown menu will never display `All` again once a dropdown menu thing has been selected. Might need some UI feedback on this...

`Before: `
![screen shot 2018-03-28 at 12 21 49 pm](https://user-images.githubusercontent.com/15153943/38051276-ab5c59fa-3282-11e8-961a-ef094c2124e9.png)
`After:`
![screen shot 2018-03-28 at 12 21 38 pm](https://user-images.githubusercontent.com/15153943/38051277-ab703cf4-3282-11e8-918e-672bc9529de3.png)


