### PR TITLE
Fix for GPS-360, keep query when you click out of the search box

### DIFF
--- a/pivot/static/pivot/js/course.js
+++ b/pivot/static/pivot/js/course.js
@@ -161,7 +161,6 @@ function showCurrentSelections() {
 //Hide the search suggestions box
 function closeSuggestions() {
    $("#suggestions").css("display","none");
-   $("#search").val("");
    $("#search").blur();
 }
 

--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -413,13 +413,6 @@ $("#goBtn").click(function (e) {
         goSearch();
 });
 
-//hides search results and clears input
-function hideSearchSuggestions() {
-    $("#suggestions").css("display","none");
-    $("#search").val("");
-    $("#search").blur();
-}
-
 /*** COLLEGE DROPDOWN ****/
 //Called when data files have been read - populates college dropdown menu
 function populateCollegeDropdown() {

--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -570,11 +570,9 @@ $("html").keydown(function (e) {
 
 //hides search results and clears input
 function hideSearchSuggestions() {
-    console.log("hide me!");
     $("#suggestions").css("display","none");
-       $("#search").val("");
-       $("#search").blur();
-       $("#search").attr("aria-expanded", "false");
+    $("#search").blur();
+    $("#search").attr("aria-expanded", "false");
 }
 
 //Search major list for text in input field


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/GPS-360
Before (the query would disappear when you clicked out if you had valid searches, wouldn't disappear if it was invalid though...):
![beforeerase](https://user-images.githubusercontent.com/15153943/38212171-a6b073a8-3671-11e8-9bf9-d1593595b4e5.gif)
After (keeps query in both situations):
![erase](https://user-images.githubusercontent.com/15153943/38212153-9c0d16fe-3671-11e8-9c6e-ca3fc1c61a2b.gif)

Also deleted `hideSearchSuggestions` from main.js since it wasn't being used at all (only the `hideSearchSuggestions` in major.js was used)