### PR TITLE
GPS-376: If you select a protected major, you change keyboard nav on dropdown

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -458,7 +458,6 @@ function noResults() {
 
 function protectedResult(protected_list) {
     $(".sample-data").css("display","none");
-    $("#suggestions").css("display","none");
     $(".protected-result-warning").css("display","inline");
 
     var source = $("#protected-result-warning").html();


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/GPS-376

I don't think we want to remove the `#suggestions` dropdown when a protected major is selected. We want to continue to allow a user to select majors in the dropdown (and instead just place a box saying that the protected major was selected).