### PR TITLE
stop generating the data map on the about page

### DIFF
--- a/pivot/static/pivot/js/main.js
+++ b/pivot/static/pivot/js/main.js
@@ -15,10 +15,12 @@ var all_data_loaded = false;
 var _searchResultsChecked = false;
 
 /**** SETUP ****/
-if (window.location.search == "?slow") {
-    window.setTimeout(function() { getDataNameMap(); }, 5000);
-} else {
-    getDataNameMap();
+if (window.location.pathname != "/about/") {
+    if (window.location.search == "?slow") {
+        window.setTimeout(function() { getDataNameMap(); }, 5000);
+    } else {
+        getDataNameMap();
+    }
 }
 
 // initializes app


### PR DESCRIPTION
it's unnecessary for the about page's functionality and relies on functions that are defined only in major.js