### PR TITLE
expanded compatibility of error message with screen readers by changi…

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -447,12 +447,12 @@ function noResults() {
     var template = Handlebars.compile(source);
     $(".sample-data").css("display","none");
     $("#suggestions").css("display","none");
-    $(".no-results-warning").css("display","inline");
     if (multipleSelected())
         $(".no-results-warning");
     $(".no-results-warning").html(template({
         search: $("input#search").val()
     }));
+    $(".no-results-warning").css("display","block");
     //$("#loadingModal").modal('hide');
 }
 

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -12,7 +12,7 @@
         {% include "head.html" %}
     </head>
 
-<body>
+<body role="application">
     <div class="page-wrap"> <!-- another wrap to make a sticky footer -->
         <header class="topbanner-bg" role="banner">
             <div class="container" >

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -12,7 +12,7 @@
         {% include "head.html" %}
     </head>
 
-<body role="application">
+<body>
     <div class="page-wrap"> <!-- another wrap to make a sticky footer -->
         <header class="topbanner-bg" role="banner">
             <div class="container" >

--- a/pivot/templates/handlebars/no-results.html
+++ b/pivot/templates/handlebars/no-results.html
@@ -1,6 +1,6 @@
 {% load templatetag_handlebars %}
 {% tplhandlebars "no-results" %}
-<div class="no-results-warning alert alert-info" role="alert" aria-atomic="true">
+<div class="no-results-warning alert alert-info" role="alert" aria-live="assertive" aria-atomic="true">
 <p>
     <b>Can't find keyword {{ search }} in UW major list.</b>
 </p>

--- a/pivot/templates/major-gpa.html
+++ b/pivot/templates/major-gpa.html
@@ -53,7 +53,7 @@
 				</div><!-- end of .panel panel-default -->
 		    </section>
            <!-- placeholder for 0 results warning -->
-            <div class='no-results-warning' role="alert">
+            <div class='no-results-warning'>
             </div>
             <div class='protected-result-warning' role="alert">
             </div>


### PR DESCRIPTION
…ng the css of the inner div as well

new solution works on chrome (mac and windows), Firefox (windows only, Firefox is incompatible with voiceover), and Safari. It is also incompatible with Internet explorer due to either poor support for aria-role or aria-live (probably both). Also changed the body's role to application.