### PR TITLE
swap out colons from major codes

### DIFF
--- a/pivot/views/data_api.py
+++ b/pivot/views/data_api.py
@@ -63,6 +63,7 @@ class DataFileView(View):
             for row in csv_reader:
                 for index in check_index:
                     row[index] = row[index].replace("&", "_AND_")
+                    row[index] = row[index].replace(":", "_")
                 cw.writerow(row)
             return si.getvalue().strip('\r\n')
 


### PR DESCRIPTION
No major codes currently have colons, but just in case they eventually do. Colons are not valid ID chars