### PR TITLE
Removed no-hover class from Pivot heading & removed no-hover rule in css

### DIFF
--- a/pivot/static/pivot/css/styles.less
+++ b/pivot/static/pivot/css/styles.less
@@ -123,10 +123,6 @@ a:focus { /* Hyperlink style:*/
 	border: 1px dotted;
 }
 
-a.no-hover:hover, a.no-hover:focus {
-    text-decoration: none;
-    border:none;
-}
 /* Skip to #main-content button at top */
 a.skip-to-main {
 	position: absolute;

--- a/pivot/static/pivot/css/styles.less
+++ b/pivot/static/pivot/css/styles.less
@@ -123,6 +123,10 @@ a:focus { /* Hyperlink style:*/
 	border: 1px dotted;
 }
 
+a.no-hover:hover, a.no-hover:focus {
+    text-decoration: none;
+}
+
 /* Skip to #main-content button at top */
 a.skip-to-main {
 	position: absolute;

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -20,7 +20,7 @@
                 <section class="topbanner" >
 	                <a href="#maincontent" id="shortcut" class="skip-to-main">skip to main content</a>
                     <nav class="navbar navbar-default" role="navigation">
-                        <a href="/major-gpa/" class="no-hover"><span class="sitename">Pivot</span></a>
+                        <a href="/major-gpa/"><span class="sitename">Pivot</span></a>
                         <span class="tagline">Help your students make the best move</span>
                         <!-- Hide NetID for Beta 		<div class="login"> Hi, netid123 </div> -->
                         <!-- Hamburger for 768px -->

--- a/pivot/templates/base.html
+++ b/pivot/templates/base.html
@@ -20,7 +20,7 @@
                 <section class="topbanner" >
 	                <a href="#maincontent" id="shortcut" class="skip-to-main">skip to main content</a>
                     <nav class="navbar navbar-default" role="navigation">
-                        <a href="/major-gpa/"><span class="sitename">Pivot</span></a>
+                        <a href="/major-gpa/" class="no-hover"><span class="sitename">Pivot</span></a>
                         <span class="tagline">Help your students make the best move</span>
                         <!-- Hide NetID for Beta 		<div class="login"> Hi, netid123 </div> -->
                         <!-- Hamburger for 768px -->


### PR DESCRIPTION
The no-hover class is not used anywhere else, caused the heading to shift position with the border: none property