### PR TITLE
Replaced window.scrollY with window.pageYOffset

### DIFF
--- a/pivot/static/pivot/js/major.js
+++ b/pivot/static/pivot/js/major.js
@@ -31,7 +31,7 @@ function checkStoredData() {
             window.scrollTo(0, lastYPos);
         }
         $(window).scroll(function () {
-            localStorage.setItem('scrollYPos', window.scrollY);
+            localStorage.setItem('scrollYPos', window.pageYOffset);
         });
     }
 }


### PR DESCRIPTION
Fixes the remainder of GPS-425, window.scrollY is not compatible with IE11 while window.pageYOffset is compatible with all browsers