### PR TITLE
Pin psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-psycopg2
+# psycopg2 maybe able to be upgraded upon moving to a newer django
+psycopg2<2.9
 -e .


### PR DESCRIPTION
2.9 introduces AssertionError: database connection isn't set to UTC in some versions of Django